### PR TITLE
feat(core): added *cookies directive

### DIFF
--- a/projects/platform/src/lib/directives/cookies.directive.ts
+++ b/projects/platform/src/lib/directives/cookies.directive.ts
@@ -1,0 +1,135 @@
+import { Directive, Input, TemplateRef, ViewContainerRef, EmbeddedViewRef, OnChanges, SimpleChanges } from '@angular/core';
+import { CookieOptionsArgs, CookiesService } from '../tools/cookies.tools';
+
+enum CookiesStrategies {
+    GET = 'get',
+    SET = 'set',
+    REMOVE = 'remove'
+}
+
+interface CookiesContext {
+    $implicit: any;
+    data: any;
+}
+
+interface CookiesStrategy {
+    type: CookiesStrategies;
+    changes: string[];
+    require: string[];
+}
+
+const COOKIES_CONFIG: CookiesStrategy[] = [
+    {
+        type: CookiesStrategies.GET,
+        changes: ['cookiesGet'],
+        require: ['cookiesGet']
+    },
+    {
+        type: CookiesStrategies.SET,
+        changes: [
+            'cookiesSet',
+            'cookiesValue',
+            'cookiesPath',
+            'cookiesDomain',
+            'cookiesExpires',
+            'cookiesSecure'
+        ],
+        require: ['cookiesSet']
+    },
+    {
+        type: CookiesStrategies.REMOVE,
+        changes: ['cookiesRemove', 'cookiesPath', 'cookiesDomain'],
+        require: ['cookiesRemove']
+    },
+];
+
+
+@Directive({ selector: '[cookies]' })
+export class CookiesDirective implements OnChanges {
+
+    @Input() private cookiesGet: string;
+    @Input() private cookiesSet: string;
+    @Input() private cookiesRemove: string;
+    @Input() private cookiesValue: any;
+
+    @Input() private cookiesPath: string;
+    @Input() private cookiesDomain: string;
+    @Input() private cookiesExpires: string | Date;
+    @Input() private cookiesSecure: boolean;
+
+    private context: CookiesContext = {
+        $implicit: null,
+        get data() {
+            return this.$implicit;
+        }
+    };
+
+    private viewRef: EmbeddedViewRef<CookiesContext> =
+        this.viewContainerRef.createEmbeddedView(this.templateRef, this.context);
+
+    constructor(
+        private templateRef: TemplateRef<CookiesContext>,
+        private viewContainerRef: ViewContainerRef,
+        private cookiesService: CookiesService
+    ) {
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        const strategy: CookiesStrategy = this.findStrategy(changes);
+
+        if (strategy) {
+            this.execute(strategy);
+        }
+    }
+
+    private findStrategy(changes: SimpleChanges): CookiesStrategy {
+        return COOKIES_CONFIG.find((strategy) => {
+            return strategy.changes.some(field => !!changes[field])
+                && strategy.require.every(field => !!this[field]);
+        });
+    }
+
+    private execute(strategy: CookiesStrategy): void {
+        const options = strategy.changes.map(field => this[field]);
+
+        this.action(strategy.type, ...options);
+    }
+
+    private action(type: string, ...options: string[]): void {
+        const name = options[0];
+        const value = options[1];
+        const cookieOptions: CookieOptionsArgs = {
+            path: options[2],
+            domain: options[3],
+            expires: options[4],
+            secure: !!options[5]
+        };
+
+        if (CookiesStrategies.GET === type) {
+            this.context.$implicit = this.getCookie(name);
+        }
+
+        if (CookiesStrategies.SET === type) {
+            this.setCookie(name, value, cookieOptions);
+            this.context.$implicit = value;
+        }
+
+        if (CookiesStrategies.REMOVE === type) {
+            this.removeCookie(name, cookieOptions);
+            this.context.$implicit = undefined;
+        }
+
+        this.viewRef.markForCheck();
+    }
+
+    private getCookie(name: string): string {
+        return this.cookiesService.get(name);
+    }
+
+    private setCookie(name: string, value: string, options?: CookieOptionsArgs): void {
+        this.cookiesService.set(name, value, options);
+    }
+    private removeCookie(name: string, options?: CookieOptionsArgs): void {
+        this.cookiesService.remove(name, options);
+    }
+}

--- a/projects/platform/src/lib/directives/index.ts
+++ b/projects/platform/src/lib/directives/index.ts
@@ -3,6 +3,7 @@ import { RouteDirective } from './route.directive';
 import { InitDirective } from './init.directive';
 import { TimeoutDirective } from './timeout.directive';
 import { ComposeDirective, ReturnDirective } from './compose.directive';
+import { CookiesDirective } from './cookies.directive';
 
 export const DIRECTIVES = [
     HttpDirective,
@@ -10,7 +11,8 @@ export const DIRECTIVES = [
     InitDirective,
     TimeoutDirective,
     ComposeDirective,
-    ReturnDirective
+    ReturnDirective,
+    CookiesDirective
 ];
 
 export * from './http.directive';
@@ -18,3 +20,4 @@ export * from './route.directive';
 export * from './init.directive';
 export * from './timeout.directive';
 export * from './compose.directive';
+export * from './cookies.directive';

--- a/projects/platform/src/lib/platform.module.ts
+++ b/projects/platform/src/lib/platform.module.ts
@@ -1,25 +1,28 @@
 import { NgModule } from '@angular/core';
 import {
-  HttpDirective,
-  RouteDirective,
-  InitDirective,
-  TimeoutDirective,
-  ComposeDirective,
-  ReturnDirective
+    HttpDirective,
+    RouteDirective,
+    InitDirective,
+    TimeoutDirective,
+    ComposeDirective,
+    ReturnDirective,
+    CookiesDirective
 } from './directives';
 
 const DIRECTIVES = [
-  HttpDirective,
-  RouteDirective,
-  InitDirective,
-  TimeoutDirective,
-  ComposeDirective,
-  ReturnDirective
+    HttpDirective,
+    RouteDirective,
+    InitDirective,
+    TimeoutDirective,
+    ComposeDirective,
+    ReturnDirective,
+    CookiesDirective
 ];
 
 @NgModule({
-  imports: [],
-  declarations: [ DIRECTIVES ],
-  exports: [ DIRECTIVES ]
+    imports: [],
+    declarations: [DIRECTIVES],
+    exports: [DIRECTIVES]
 })
-export class NgxfModule { }
+export class NgxfModule {
+}

--- a/projects/platform/src/lib/tools/cookies.tools.ts
+++ b/projects/platform/src/lib/tools/cookies.tools.ts
@@ -1,0 +1,146 @@
+import { Inject, Injectable, Optional } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+
+export interface CookieOptionsArgs {
+    path?: string;
+    domain?: string;
+    expires?: string | Date;
+    secure?: boolean;
+}
+
+export interface ICookies {
+    [key: string]: string[];
+}
+
+export interface ICookieService {
+    get(key: string): string;
+    set(key: string, value: string, options?: CookieOptionsArgs): void;
+    remove(key: string, options?: CookieOptionsArgs): void;
+}
+
+export class CookieOptions {
+
+    public path: string;
+    public domain: string;
+    public expires: string | Date;
+    public secure: boolean;
+
+    constructor({ path, domain, expires, secure }: CookieOptionsArgs = {}) {
+        this.path = this.isPresent(path) ? path : null;
+        this.domain = this.isPresent(domain) ? domain : null;
+        this.expires = this.isPresent(expires) ? expires : null;
+        this.secure = this.isPresent(secure) ? secure : false;
+    }
+
+    public merge(options?: CookieOptionsArgs): CookieOptions {
+        return new CookieOptions(<CookieOptionsArgs>{
+            path: this.isPresent(options) && this.isPresent(options.path) ? options.path : this.path,
+            domain: this.isPresent(options) && this.isPresent(options.domain) ? options.domain : this.domain,
+            expires: this.isPresent(options) && this.isPresent(options.expires) ? options.expires : this.expires,
+            secure: this.isPresent(options) && this.isPresent(options.secure) ? options.secure : this.secure,
+        });
+    }
+
+    private isPresent(obj: any): boolean {
+        return obj !== undefined && obj !== null;
+    }
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class BaseCookieOptions extends CookieOptions {
+    constructor(@Optional() @Inject(APP_BASE_HREF) private baseHref: string) {
+        super({ path: baseHref || '/' });
+    }
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class CookiesService implements ICookieService {
+
+    constructor(
+        @Optional() private defaultOptions?: CookieOptions
+    ) {
+    }
+
+    protected get cookieString(): string {
+        return document.cookie || '';
+    }
+
+    protected set cookieString(val: string) {
+        document.cookie = val;
+    }
+
+    private cookieReader(key: string): string {
+        const currentCookieString = this.cookieString;
+
+        if (currentCookieString) {
+            const cookieArray = currentCookieString.split('; ');
+
+            return cookieArray.reduce((cookies: ICookies, current: string) => {
+                const cookie = current.split('=');
+
+                return { ...cookies, [cookie[0]]: decodeURIComponent(cookie[1]) };
+            }, {})[key];
+        }
+    }
+
+    private cookieWriter(name: string, value: string, options?: CookieOptionsArgs) {
+        this.cookieString = this.buildCookieString(name, value, options);
+    }
+
+    private buildCookieString(name: string, value: string, options?: CookieOptionsArgs): string {
+        const defaultOpts = this.defaultOptions || new CookieOptions(<CookieOptionsArgs>{ path: '/' });
+        const opts: CookieOptions = this.mergeOptions(defaultOpts, options);
+
+        let expires = opts.expires;
+
+        if (!value) {
+            expires = 'Thu, 01 Jan 1970 00:00:00 GMT';
+            value = '';
+        }
+
+        if (typeof expires === 'string') {
+            expires = new Date(expires);
+        }
+
+        let str = encodeURIComponent(name) + '=' + encodeURIComponent(value);
+
+        str += opts.path ? `;path=${opts.path}` : '';
+        str += opts.domain ? `;domain=${opts.domain}` : '';
+        str += expires ? `;expires=${expires.toUTCString()}` : '';
+        str += opts.secure ? ';secure' : '';
+
+        const cookieLength = str.length + 1;
+
+        if (cookieLength > 4096) {
+            console.log(`Cookie \'${name}\' possibly not set or overflowed because it was too large (${cookieLength} > 4096 bytes)!`);
+        }
+
+        return str;
+    }
+
+    private mergeOptions(defaultOpts: CookieOptions, providedOpts?: CookieOptionsArgs): CookieOptions {
+        const newOpts = defaultOpts;
+
+        if (providedOpts) {
+            return newOpts.merge(new CookieOptions(providedOpts));
+        }
+
+        return newOpts;
+    }
+
+    public get(key: string): string {
+        return this.cookieReader(key);
+    }
+
+    public set(key: string, value: string, options?: CookieOptionsArgs): void {
+        this.cookieWriter(key, value, options);
+    }
+
+    public remove(key: string, options?: CookieOptionsArgs): void {
+        this.cookieWriter(key, undefined, options);
+    }
+}

--- a/projects/platform/src/lib/tools/index.ts
+++ b/projects/platform/src/lib/tools/index.ts
@@ -1,0 +1,1 @@
+export * from './cookies.tools';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,15 @@
 <!--The content below is only a placeholder and can be replaced.-->
-<router-outlet></router-outlet>
+<!--<router-outlet></router-outlet>-->
+
+<ng-container *cookies="let cookie set 'ngxf' value 'Best Of The Best' path '/' domain: 'localhost' expires '01 Oct 2020'">
+    {{ cookie }}
+</ng-container>
+
+<ng-container *cookies="let cookie get 'ngxf'">
+    {{ cookie }}
+</ng-container>
+
+
+<ng-container *cookies="let cookie remove 'ngxf' path '/' domain: 'localhost'">
+    {{ cookie }}
+</ng-container>


### PR DESCRIPTION
CookiesDirective provides tempalte composition
An Example:

<ng-container *cookies="let cookie set 'ngxf' value 'Best Of The Best' path '/' domain: 'localhost' expires '01 Oct 2020'">
    {{ cookie }}
</ng-container>

<ng-container *cookies="let cookie get 'ngxf'">
    {{ cookie }}
</ng-container>

<ng-container *cookies="let cookie remove 'ngxf' path '/' domain: 'localhost'">
    {{ cookie }}
</ng-container>